### PR TITLE
Level end fix

### DIFF
--- a/Assets/Scripts/Level/StartLoad/ChangeSceneTrigger.cs
+++ b/Assets/Scripts/Level/StartLoad/ChangeSceneTrigger.cs
@@ -11,7 +11,7 @@ public class ChangeSceneTrigger : MonoBehaviour
     public GameObject loadingScreen;
     public Slider slider;
 	
-	public bool returnTo3D;
+	public static bool returnTo3D;
 
     private void OnTriggerEnter(Collider other)
     {

--- a/Assets/Scripts/Level/StartLoad/ChangeSceneTrigger.cs
+++ b/Assets/Scripts/Level/StartLoad/ChangeSceneTrigger.cs
@@ -10,10 +10,19 @@ public class ChangeSceneTrigger : MonoBehaviour
     public Level levelToLoad;
     public GameObject loadingScreen;
     public Slider slider;
+	
+	public bool returnTo3D;
 
     private void OnTriggerEnter(Collider other)
     {
         LoadLevel((int)levelToLoad);
+        if (!returnTo3D && CameraManager.Instance.cameraState == CameraState.THIRD_PERSON)
+        {
+            CameraManager.Instance.Toggle3D2D();
+		} else if (returnTo3D && CameraManager.Instance.cameraState == CameraState.SIDE_SCROLLER) {
+			CameraManager.Instance.Toggle3D2D();
+		}
+        
     }
 
     //


### PR DESCRIPTION
**Milestone** - Fixed camera reset at level end

**Tasks Completed**

* If player is in 2D, camera resets to 3D OR if player is in 3D, camera resets to 2D
* This is toggleable by a check box in the prefab that links to a static bool

**Checked out Items**
* ChangeSceneTrigger.cs

